### PR TITLE
Fix a typo in overload's name

### DIFF
--- a/dotnet-etcd/watchClient.cs
+++ b/dotnet-etcd/watchClient.cs
@@ -1123,7 +1123,7 @@ namespace dotnet_etcd
         /// </summary>
         /// <param name="key">Key to be watched</param>
         /// <param name="methods">Methods to which minimal watch events data should be passed on</param>
-        public async void WatcRange(string path, Action<WatchEvent[]>[] methods)
+        public async void WatchRange(string path, Action<WatchEvent[]>[] methods)
         {
 
             try


### PR DESCRIPTION
I find a typo in overload's name when I use the client.

Thank you for your  creating the great client.