### PR TITLE
#43 - Expose deadline and cancellationToken in public API and provide…

### DIFF
--- a/dotnet-etcd/lockClient.cs
+++ b/dotnet-etcd/lockClient.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Google.Protobuf;
@@ -20,13 +21,17 @@ namespace dotnet_etcd
         /// lease associate with the owner expires.
         /// </summary>
         /// <param name="name">is the identifier for the distributed shared lock to be acquired.</param>
+        /// <param name="headers">The initial metadata to send with the call. This parameter is optional.</param>
+        /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
+        /// <param name="cancellationToken">An optional token for canceling the call.</param>
         /// <returns></returns>
-        public LockResponse Lock(string name, Grpc.Core.Metadata headers = null)
+        public LockResponse Lock(string name, Grpc.Core.Metadata headers = null, DateTime? deadline = null,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
             return Lock(new LockRequest()
             {
                 Name = ByteString.CopyFromUtf8(name),
-            }, headers);
+            }, headers, deadline, cancellationToken);
         }
 
         /// <summary>
@@ -38,8 +43,12 @@ namespace dotnet_etcd
         /// lease associate with the owner expires.
         /// </summary>
         /// <param name="request">The request to send to the server</param>
+        /// <param name="headers">The initial metadata to send with the call. This parameter is optional.</param>
+        /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
+        /// <param name="cancellationToken">An optional token for canceling the call.</param>
         /// <returns></returns>
-        public LockResponse Lock(LockRequest request, Grpc.Core.Metadata headers = null)
+        public LockResponse Lock(LockRequest request, Grpc.Core.Metadata headers = null, DateTime? deadline = null,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
             LockResponse response = new LockResponse();
             bool success = false;
@@ -48,7 +57,7 @@ namespace dotnet_etcd
             {
                 try
                 {
-                    response = _balancer.GetConnection().lockClient.Lock(request, headers);
+                    response = _balancer.GetConnection().lockClient.Lock(request, headers, deadline, cancellationToken);
                     success = true;
                 }
                 catch (RpcException ex) when (ex.StatusCode == StatusCode.Unavailable)
@@ -60,6 +69,7 @@ namespace dotnet_etcd
                     }
                 }
             }
+
             return response;
         }
 
@@ -72,13 +82,17 @@ namespace dotnet_etcd
         /// lease associate with the owner expires.
         /// </summary>
         /// <param name="name">is the identifier for the distributed shared lock to be acquired.</param>
+        /// <param name="headers">The initial metadata to send with the call. This parameter is optional.</param>
+        /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
+        /// <param name="cancellationToken">An optional token for canceling the call.</param>
         /// <returns></returns>
-        public async Task<LockResponse> LockAsync(string name, Grpc.Core.Metadata headers = null)
+        public async Task<LockResponse> LockAsync(string name, Grpc.Core.Metadata headers = null,
+            DateTime? deadline = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return await LockAsync(new LockRequest()
             {
                 Name = ByteString.CopyFromUtf8(name),
-            }, headers);
+            }, headers, deadline, cancellationToken);
         }
 
         /// <summary>
@@ -90,8 +104,12 @@ namespace dotnet_etcd
         /// lease associate with the owner expires.
         /// </summary>
         /// <param name="request">The request to send to the server</param>
+        /// <param name="headers">The initial metadata to send with the call. This parameter is optional.</param>
+        /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
+        /// <param name="cancellationToken">An optional token for canceling the call.</param>
         /// <returns></returns>
-        public async Task<LockResponse> LockAsync(LockRequest request, Grpc.Core.Metadata headers = null)
+        public async Task<LockResponse> LockAsync(LockRequest request, Grpc.Core.Metadata headers = null,
+            DateTime? deadline = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             LockResponse response = new LockResponse();
             bool success = false;
@@ -100,7 +118,8 @@ namespace dotnet_etcd
             {
                 try
                 {
-                    response = await _balancer.GetConnection().lockClient.LockAsync(request, headers);
+                    response = await _balancer.GetConnection().lockClient
+                        .LockAsync(request, headers, deadline, cancellationToken);
                     success = true;
                 }
                 catch (RpcException ex) when (ex.StatusCode == StatusCode.Unavailable)
@@ -112,6 +131,7 @@ namespace dotnet_etcd
                     }
                 }
             }
+
             return response;
         }
 
@@ -121,13 +141,17 @@ namespace dotnet_etcd
         /// ownership of the lock.
         /// </summary>
         /// <param name="key">the lock ownership key granted by Lock.</param>
+        /// <param name="headers">The initial metadata to send with the call. This parameter is optional.</param>
+        /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
+        /// <param name="cancellationToken">An optional token for canceling the call.</param>
         /// <returns></returns>
-        public UnlockResponse Unlock(string key, Grpc.Core.Metadata headers = null)
+        public UnlockResponse Unlock(string key, Grpc.Core.Metadata headers = null, DateTime? deadline = null,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
             return Unlock(new UnlockRequest()
             {
                 Key = ByteString.CopyFromUtf8(key),
-            }, headers);
+            }, headers, deadline, cancellationToken);
         }
 
         /// <summary>
@@ -136,8 +160,12 @@ namespace dotnet_etcd
         /// ownership of the lock.
         /// </summary>
         /// <param name="request">The request to send to the server</param>
+        /// <param name="headers">The initial metadata to send with the call. This parameter is optional.</param>
+        /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
+        /// <param name="cancellationToken">An optional token for canceling the call.</param>
         /// <returns></returns>
-        public UnlockResponse Unlock(UnlockRequest request, Grpc.Core.Metadata headers = null)
+        public UnlockResponse Unlock(UnlockRequest request, Grpc.Core.Metadata headers = null,
+            DateTime? deadline = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             UnlockResponse response = new UnlockResponse();
             bool success = false;
@@ -146,7 +174,8 @@ namespace dotnet_etcd
             {
                 try
                 {
-                    response = _balancer.GetConnection().lockClient.Unlock(request, headers);
+                    response = _balancer.GetConnection().lockClient
+                        .Unlock(request, headers, deadline, cancellationToken);
                     success = true;
                 }
                 catch (RpcException ex) when (ex.StatusCode == StatusCode.Unavailable)
@@ -158,6 +187,7 @@ namespace dotnet_etcd
                     }
                 }
             }
+
             return response;
         }
 
@@ -167,13 +197,17 @@ namespace dotnet_etcd
         /// ownership of the lock.
         /// </summary>
         /// <param name="key">the lock ownership key granted by Lock.</param>
+        /// <param name="headers">The initial metadata to send with the call. This parameter is optional.</param>
+        /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
+        /// <param name="cancellationToken">An optional token for canceling the call.</param>
         /// <returns></returns>
-        public async Task<UnlockResponse> UnlockAsync(string key, Grpc.Core.Metadata headers = null)
+        public async Task<UnlockResponse> UnlockAsync(string key, Grpc.Core.Metadata headers = null,
+            DateTime? deadline = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return await UnlockAsync(new UnlockRequest()
             {
                 Key = ByteString.CopyFromUtf8(key),
-            }, headers);
+            }, headers, deadline, cancellationToken);
         }
 
         /// <summary>
@@ -182,8 +216,12 @@ namespace dotnet_etcd
         /// ownership of the lock.
         /// </summary>
         /// <param name="request">The request to send to the server</param>
+        /// <param name="headers">The initial metadata to send with the call. This parameter is optional.</param>
+        /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
+        /// <param name="cancellationToken">An optional token for canceling the call.</param>
         /// <returns></returns>
-        public async Task<UnlockResponse> UnlockAsync(UnlockRequest request, Grpc.Core.Metadata headers = null)
+        public async Task<UnlockResponse> UnlockAsync(UnlockRequest request, Grpc.Core.Metadata headers = null,
+            DateTime? deadline = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             UnlockResponse response = new UnlockResponse();
             bool success = false;
@@ -192,7 +230,8 @@ namespace dotnet_etcd
             {
                 try
                 {
-                    response = await _balancer.GetConnection().lockClient.UnlockAsync(request, headers);
+                    response = await _balancer.GetConnection().lockClient
+                        .UnlockAsync(request, headers, deadline, cancellationToken);
                     success = true;
                 }
                 catch (RpcException ex) when (ex.StatusCode == StatusCode.Unavailable)
@@ -204,6 +243,7 @@ namespace dotnet_etcd
                     }
                 }
             }
+
             return response;
         }
     }


### PR DESCRIPTION
Added the deadline and cancellationToken to the public API of all the methods in the 'lockClient' and updated the documentation for this methods. 

PR implements the improvements of #43
