### PR TITLE
Add .NET5 target

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A C# .NET (dotnet) GRPC client for etcd v3+
 
 ## Supported .NET Versions
 
+* .NET 5
 * .NETCoreApp 3.1
 * .NETCoreApp 3.0
 * .NETCoreApp 2.2

--- a/dotnet-etcd/dotnet-etcd.csproj
+++ b/dotnet-etcd/dotnet-etcd.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks Condition="'$(LibraryFrameworks)'==''">
-      netcoreapp2.0;netcoreapp2.1;netcoreapp2.2;netcoreapp3.0;netcoreapp3.1;netstandard2.0;netstandard2.1
+      netcoreapp2.0;netcoreapp2.1;netcoreapp2.2;netcoreapp3.0;netcoreapp3.1;netstandard2.0;netstandard2.1;net5.0
     </TargetFrameworks>
     <TargetFrameworks Condition="'$(LibraryFrameworks)'!=''">$(LibraryFrameworks)</TargetFrameworks>
     <RootNamespace>dotnet_etcd</RootNamespace>
@@ -10,7 +10,7 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/shubhamranjan/dotnet-etcd</RepositoryUrl>
     <PackageProjectUrl>https://github.com/shubhamranjan/dotnet-etcd</PackageProjectUrl>
-    <PackageReleaseNotes>Range Get fix</PackageReleaseNotes>
+    <PackageReleaseNotes>Add .NET5 target</PackageReleaseNotes>
     <Authors>Shubham Ranjan</Authors>
     <Company />
     <Product />


### PR DESCRIPTION
* [christian-be/dotnet-etcd](https://github.com/christian-be/dotnet-etcd)

I think there should be a nuget targeting net5.0. Using the one for .NET Core 3.1 seems to work, but I think it would be cleaner to be able to use the one targeted for .NET 5 in these cases. I have added the target and edited the readme correspondingly.