### PR TITLE
Favor OperationCanceledException for cancellations

### DIFF
--- a/dotnet-etcd/multiplexer/Balancer.cs
+++ b/dotnet-etcd/multiplexer/Balancer.cs
@@ -51,7 +51,8 @@ namespace dotnet_etcd.multiplexer
                     channel = GrpcChannel.ForAddress(node, new GrpcChannelOptions
                     {
                         Credentials = new SslCredentials(),
-                        HttpHandler = handler
+                        HttpHandler = handler,
+                        ThrowOperationCanceledOnCancellation = true
                     });
                 }
                 else
@@ -62,7 +63,8 @@ namespace dotnet_etcd.multiplexer
                     var options = new GrpcChannelOptions
                     {
                         Credentials = ChannelCredentials.Insecure,
-                        HttpHandler = handler
+                        HttpHandler = handler,
+                        ThrowOperationCanceledOnCancellation = true
                     };
 
                     channel = GrpcChannel.ForAddress(node, options);


### PR DESCRIPTION
Favor OperationCanceledException for cancellations, otherwise RpcException will be thrown with a StatusCode of Canceled. This does not integrate well when using Tasks.

Fixes #118 