### PR TITLE
[Dependce] The type 'AnnotationsReflection' exists in both Google.Api.CommonProtos & dotnet-etcd

### DIFF
--- a/dotnet-etcd/dotnet-etcd.csproj
+++ b/dotnet-etcd/dotnet-etcd.csproj
@@ -28,7 +28,7 @@ Your applications can read and write data into etcd. A simple use-case is to sto
 Advanced uses take advantage of the consistency guarantees to implement database leader elections or do distributed locking across a cluster of workers.</Description>
     <PackageTags>etcd grpc etcdv3 etcd3</PackageTags>
     <SignAssembly>false</SignAssembly>
-    <Version>6.2.0-beta</Version>
+    <Version>6.2.0-beta.230913.1</Version>
     <AutoGenerateBindingRedirects>False</AutoGenerateBindingRedirects>
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <PackageIconUrl />
@@ -60,9 +60,10 @@ Advanced uses take advantage of the consistency guarantees to implement database
 
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.21.10" />
-    <PackageReference Include="Grpc.Net.Client" Version="2.50.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.51.0">
+    <PackageReference Include="Google.Api.CommonProtos" Version="2.5.0" />
+    <PackageReference Include="Google.Protobuf" Version="3.23.1" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.57.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.57.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -76,9 +77,6 @@ Advanced uses take advantage of the consistency guarantees to implement database
     <Protobuf Include="grpc\proto\etcd\version.proto" GrpcServices="Client" />
 
     <Protobuf Include="grpc\proto\gogoproto\gogo.proto" GrpcServices="Client" />
-
-    <Protobuf Include="grpc\proto\google\api\annotations.proto" GrpcServices="Client" />
-    <Protobuf Include="grpc\proto\google\api\http.proto" GrpcServices="Client" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Cancel compile "annotations.proto" and "http.proto" directly, Change to depend on Google.Api.CommonProtos.

- - When the user wants to use the grpc-gateway
#import "google/api/annotations.proto";
in the custom proto file.

The following situations can be avoided
CS0433 : The type 'AnnotationsReflection' exists in both Google.Api.CommonProtos & dotnet-etcd