### PR TITLE
Feature lease keep alive with cancellation token source

### DIFF
--- a/dotnet-etcd/Util.cs
+++ b/dotnet-etcd/Util.cs
@@ -67,7 +67,7 @@ namespace dotnet_etcd
         /// <typeparam name="TResponse">The type of the response that is returned from the call to etcd</typeparam>
         /// <param name="etcdCallFunc">The function to perform actions with the <seealso cref="Connection"/> object</param>
         /// <returns>The response from the the <paramref name="etcdCallFunc"/></returns>
-        private TResponse CallEtcd<TResponse>(Func<Connection, TResponse> etcdCallFunc) => etcdCallFunc.Invoke(_connection);
+        private TResponse CallEtcd<TResponse>(Func<Connection, TResponse> etcdCallFunc) => etcdCallFunc(_connection);
 
         /// <summary>
         /// Generic helper for performing actions an a connection.
@@ -77,7 +77,7 @@ namespace dotnet_etcd
         /// <typeparam name="TResponse">The type of the response that is returned from the call to etcd</typeparam>
         /// <param name="etcdCallFunc">The function to perform actions with the <seealso cref="Connection"/> object</param>
         /// <returns>The response from the the <paramref name="etcdCallFunc"/></returns>
-        private Task<TResponse> CallEtcdAsync<TResponse>(Func<Connection, Task<TResponse>> etcdCallFunc) => etcdCallFunc.Invoke(_connection);
+        private Task<TResponse> CallEtcdAsync<TResponse>(Func<Connection, Task<TResponse>> etcdCallFunc) => etcdCallFunc(_connection);
 
         /// <summary>
         /// Generic helper for performing actions an a connection.
@@ -86,6 +86,6 @@ namespace dotnet_etcd
         /// </summary>
         /// <param name="etcdCallFunc">The function to perform actions with the <seealso cref="Connection"/> object</param>
         /// <returns>The response from the the <paramref name="etcdCallFunc"/></returns>
-        private Task CallEtcdAsync(Func<Connection, Task> etcdCallFunc) => etcdCallFunc.Invoke(_connection);
+        private Task CallEtcdAsync(Func<Connection, Task> etcdCallFunc) => etcdCallFunc(_connection);
     }
 }

--- a/dotnet-etcd/authClient.cs
+++ b/dotnet-etcd/authClient.cs
@@ -21,7 +21,7 @@ namespace dotnet_etcd
         /// <returns>The response received from the server.</returns>
         public AuthenticateResponse Authenticate(AuthenticateRequest request, Grpc.Core.Metadata headers = null,
             DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection._authClient
+            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection.AuthClient
                                                                             .Authenticate(request, headers, deadline, cancellationToken));
 
         /// <summary>
@@ -34,7 +34,7 @@ namespace dotnet_etcd
         /// <returns>The response received from the server.</returns>
         public async Task<AuthenticateResponse> AuthenticateAsync(AuthenticateRequest request,
             Grpc.Core.Metadata headers = null, DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection._authClient
+            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection.AuthClient
                                                                             .AuthenticateAsync(request, headers, deadline, cancellationToken)).ConfigureAwait(false);
 
         /// <summary>
@@ -47,7 +47,7 @@ namespace dotnet_etcd
         /// <returns>The response received from the server.</returns>
         public AuthEnableResponse AuthEnable(AuthEnableRequest request, Grpc.Core.Metadata headers = null,
             DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection._authClient
+            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection.AuthClient
                                                                             .AuthEnable(request, headers, deadline, cancellationToken));
 
         /// <summary>
@@ -60,7 +60,7 @@ namespace dotnet_etcd
         /// <returns>The response received from the server.</returns>
         public async Task<AuthEnableResponse> AuthEnableAsync(AuthEnableRequest request,
             Grpc.Core.Metadata headers = null, DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection._authClient
+            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection.AuthClient
                                                                             .AuthEnableAsync(request, headers, deadline, cancellationToken)).ConfigureAwait(false);
 
         /// <summary>
@@ -73,7 +73,7 @@ namespace dotnet_etcd
         /// <returns>The response received from the server.</returns>
         public AuthDisableResponse AuthDisable(AuthDisableRequest request, Grpc.Core.Metadata headers = null,
             DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection._authClient
+            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection.AuthClient
                                                                             .AuthDisable(request, headers, deadline, cancellationToken));
 
         /// <summary>
@@ -86,7 +86,7 @@ namespace dotnet_etcd
         /// <returns>The response received from the server.</returns>
         public async Task<AuthDisableResponse> AuthDisableAsync(AuthDisableRequest request,
             Grpc.Core.Metadata headers = null, DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection._authClient
+            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection.AuthClient
                                                                             .AuthDisableAsync(request, headers, deadline, cancellationToken)).ConfigureAwait(false);
 
         /// <summary>
@@ -99,7 +99,7 @@ namespace dotnet_etcd
         /// <returns>The response received from the server.</returns>
         public AuthUserAddResponse UserAdd(AuthUserAddRequest request, Grpc.Core.Metadata headers = null,
             DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection._authClient
+            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection.AuthClient
                                                                             .UserAdd(request, headers, deadline, cancellationToken));
 
         /// <summary>
@@ -112,7 +112,7 @@ namespace dotnet_etcd
         /// <returns>The response received from the server.</returns>
         public async Task<AuthUserAddResponse> UserAddAsync(AuthUserAddRequest request,
             Grpc.Core.Metadata headers = null, DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection._authClient
+            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection.AuthClient
                                                                             .UserAddAsync(request, headers, deadline, cancellationToken)).ConfigureAwait(false);
 
         /// <summary>
@@ -125,7 +125,7 @@ namespace dotnet_etcd
         /// <returns>The response received from the server.</returns>
         public AuthUserGetResponse UserGet(AuthUserGetRequest request, Grpc.Core.Metadata headers = null,
             DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection._authClient
+            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection.AuthClient
                                                                             .UserGet(request, headers, deadline, cancellationToken));
 
         /// <summary>
@@ -138,7 +138,7 @@ namespace dotnet_etcd
         /// <returns>The response received from the server.</returns>
         public async Task<AuthUserGetResponse> UserGetAsync(AuthUserGetRequest request,
             Grpc.Core.Metadata headers = null, DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection._authClient
+            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection.AuthClient
                                                                             .UserGetAsync(request, headers, deadline, cancellationToken)).ConfigureAwait(false);
 
         /// <summary>
@@ -151,7 +151,7 @@ namespace dotnet_etcd
         /// <returns>The response received from the server.</returns>
         public AuthUserListResponse UserList(AuthUserListRequest request, Grpc.Core.Metadata headers = null,
             DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection._authClient
+            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection.AuthClient
                                                                             .UserList(request, headers, deadline, cancellationToken));
 
         /// <summary>
@@ -164,7 +164,7 @@ namespace dotnet_etcd
         /// <returns>The response received from the server.</returns>
         public async Task<AuthUserListResponse> UserListAsync(AuthUserListRequest request,
             Grpc.Core.Metadata headers = null, DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection._authClient
+            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection.AuthClient
                                                                             .UserListAsync(request, headers, deadline, cancellationToken)).ConfigureAwait(false);
 
         /// <summary>
@@ -177,7 +177,7 @@ namespace dotnet_etcd
         /// <returns>The response received from the server.</returns>
         public AuthUserDeleteResponse UserDelete(AuthUserDeleteRequest request, Grpc.Core.Metadata headers = null,
             DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection._authClient
+            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection.AuthClient
                                                                             .UserDelete(request, headers, deadline, cancellationToken));
 
         /// <summary>
@@ -190,7 +190,7 @@ namespace dotnet_etcd
         /// <returns>The response received from the server.</returns>
         public async Task<AuthUserDeleteResponse> UserDeleteAsync(AuthUserDeleteRequest request,
             Grpc.Core.Metadata headers = null, DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection._authClient
+            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection.AuthClient
                                                                             .UserDeleteAsync(request, headers, deadline, cancellationToken)).ConfigureAwait(false);
 
         /// <summary>
@@ -203,7 +203,7 @@ namespace dotnet_etcd
         /// <returns>The response received from the server.</returns>
         public AuthUserChangePasswordResponse UserChangePassword(AuthUserChangePasswordRequest request,
             Grpc.Core.Metadata headers = null, DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection._authClient
+            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection.AuthClient
                                                                             .UserChangePassword(request, headers, deadline, cancellationToken));
 
         /// <summary>
@@ -216,7 +216,7 @@ namespace dotnet_etcd
         /// <returns>The response received from the server.</returns>
         public async Task<AuthUserChangePasswordResponse> UserChangePasswordAsync(AuthUserChangePasswordRequest request,
             Grpc.Core.Metadata headers = null, DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection._authClient
+            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection.AuthClient
                                                                             .UserChangePasswordAsync(request, headers, deadline, cancellationToken)).ConfigureAwait(false);
 
         /// <summary>
@@ -229,7 +229,7 @@ namespace dotnet_etcd
         /// <returns>The response received from the server.</returns>
         public AuthUserGrantRoleResponse UserGrantRole(AuthUserGrantRoleRequest request,
             Grpc.Core.Metadata headers = null, DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection._authClient
+            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection.AuthClient
                                                                             .UserGrantRole(request, headers, deadline, cancellationToken));
 
         /// <summary>
@@ -242,7 +242,7 @@ namespace dotnet_etcd
         /// <returns>The response received from the server.</returns>
         public async Task<AuthUserGrantRoleResponse> UserGrantRoleAsync(AuthUserGrantRoleRequest request,
             Grpc.Core.Metadata headers = null, DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection._authClient
+            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection.AuthClient
                                                                             .UserGrantRoleAsync(request, headers, deadline, cancellationToken)).ConfigureAwait(false);
 
         /// <summary>
@@ -255,7 +255,7 @@ namespace dotnet_etcd
         /// <returns>The response received from the server.</returns>
         public AuthUserRevokeRoleResponse UserRevokeRole(AuthUserRevokeRoleRequest request,
             Grpc.Core.Metadata headers = null, DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection._authClient
+            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection.AuthClient
                                                                             .UserRevokeRole(request, headers, deadline, cancellationToken));
 
         /// <summary>
@@ -268,7 +268,7 @@ namespace dotnet_etcd
         /// <returns>The response received from the server.</returns>
         public async Task<AuthUserRevokeRoleResponse> UserRevokeRoleAsync(AuthUserRevokeRoleRequest request,
             Grpc.Core.Metadata headers = null, DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection._authClient
+            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection.AuthClient
                                                                             .UserRevokeRoleAsync(request, headers, deadline, cancellationToken)).ConfigureAwait(false);
 
         /// <summary>
@@ -281,7 +281,7 @@ namespace dotnet_etcd
         /// <returns>The response received from the server.</returns>
         public AuthRoleAddResponse RoleAdd(AuthRoleAddRequest request, Grpc.Core.Metadata headers = null,
             DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection._authClient
+            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection.AuthClient
                                                                             .RoleAdd(request, headers, deadline, cancellationToken));
 
         /// <summary>
@@ -294,7 +294,7 @@ namespace dotnet_etcd
         /// <returns>The response received from the server.</returns>
         public async Task<AuthRoleAddResponse> RoleAddAsync(AuthRoleAddRequest request,
             Grpc.Core.Metadata headers = null, DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection._authClient
+            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection.AuthClient
                                                                             .RoleAddAsync(request, headers, deadline, cancellationToken)).ConfigureAwait(false);
 
         /// <summary>
@@ -307,7 +307,7 @@ namespace dotnet_etcd
         /// <returns>The response received from the server.</returns>
         public AuthRoleGetResponse RoleGet(AuthRoleGetRequest request, Grpc.Core.Metadata headers = null,
             DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection._authClient
+            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection.AuthClient
                                                                             .RoleGet(request, headers, deadline, cancellationToken));
 
         /// <summary>
@@ -320,7 +320,7 @@ namespace dotnet_etcd
         /// <returns>The response received from the server.</returns>
         public async Task<AuthRoleGetResponse> RoleGetAsync(AuthRoleGetRequest request,
             Grpc.Core.Metadata headers = null, DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection._authClient
+            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection.AuthClient
                                                                             .RoleGetAsync(request, headers, deadline, cancellationToken)).ConfigureAwait(false);
 
         /// <summary>
@@ -333,7 +333,7 @@ namespace dotnet_etcd
         /// <returns>The response received from the server.</returns>
         public AuthRoleListResponse RoleList(AuthRoleListRequest request, Grpc.Core.Metadata headers = null,
             DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection._authClient
+            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection.AuthClient
                                                                             .RoleList(request, headers, deadline, cancellationToken));
 
         /// <summary>
@@ -346,7 +346,7 @@ namespace dotnet_etcd
         /// <returns>The response received from the server.</returns>
         public async Task<AuthRoleListResponse> RoleListAsync(AuthRoleListRequest request,
             Grpc.Core.Metadata headers = null, DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection._authClient
+            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection.AuthClient
                                                                             .RoleListAsync(request, headers, deadline, cancellationToken)).ConfigureAwait(false);
 
         /// <summary>
@@ -359,7 +359,7 @@ namespace dotnet_etcd
         /// <returns>The response received from the server.</returns>
         public AuthRoleDeleteResponse RoleDelete(AuthRoleDeleteRequest request, Grpc.Core.Metadata headers = null,
             DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection._authClient
+            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection.AuthClient
                                                                             .RoleDelete(request, headers, deadline, cancellationToken));
 
         /// <summary>
@@ -372,7 +372,7 @@ namespace dotnet_etcd
         /// <returns>The response received from the server.</returns>
         public async Task<AuthRoleDeleteResponse> RoleDeleteAsync(AuthRoleDeleteRequest request,
             Grpc.Core.Metadata headers = null, DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection._authClient
+            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection.AuthClient
                                                                             .RoleDeleteAsync(request, headers, deadline, cancellationToken)).ConfigureAwait(false);
 
         /// <summary>
@@ -385,7 +385,7 @@ namespace dotnet_etcd
         /// <returns>The response received from the server.</returns>
         public AuthRoleGrantPermissionResponse RoleGrantPermission(AuthRoleGrantPermissionRequest request,
             Grpc.Core.Metadata headers = null, DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection._authClient
+            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection.AuthClient
                                                                             .RoleGrantPermission(request, headers, deadline, cancellationToken));
 
         /// <summary>
@@ -398,7 +398,7 @@ namespace dotnet_etcd
         /// <returns>The response received from the server.</returns>
         public async Task<AuthRoleGrantPermissionResponse> RoleGrantPermissionAsync(
             AuthRoleGrantPermissionRequest request, Grpc.Core.Metadata headers = null, DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection._authClient
+            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection.AuthClient
                                                                             .RoleGrantPermissionAsync(request, headers, deadline, cancellationToken)).ConfigureAwait(false);
 
         /// <summary>
@@ -411,7 +411,7 @@ namespace dotnet_etcd
         /// <returns>The response received from the server.</returns>
         public AuthRoleRevokePermissionResponse RoleRevokePermission(AuthRoleRevokePermissionRequest request,
             Grpc.Core.Metadata headers = null, DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection._authClient
+            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection.AuthClient
                                                                             .RoleRevokePermission(request, headers, deadline, cancellationToken));
 
         /// <summary>
@@ -424,7 +424,7 @@ namespace dotnet_etcd
         /// <returns>The response received from the server.</returns>
         public async Task<AuthRoleRevokePermissionResponse> RoleRevokePermissionAsync(
             AuthRoleRevokePermissionRequest request, Grpc.Core.Metadata headers = null, DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection._authClient
+            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection.AuthClient
                                                                             .RoleRevokePermissionAsync(request, headers, deadline, cancellationToken)).ConfigureAwait(false);
     }
 }

--- a/dotnet-etcd/clusterClient.cs
+++ b/dotnet-etcd/clusterClient.cs
@@ -21,7 +21,7 @@ namespace dotnet_etcd
         /// <returns>The response received from the server.</returns>
         public MemberAddResponse MemberAdd(MemberAddRequest request, Grpc.Core.Metadata headers = null,
             DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection._clusterClient
+            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection.ClusterClient
                                                                             .MemberAdd(request, headers, deadline, cancellationToken));
 
         /// <summary>
@@ -34,7 +34,7 @@ namespace dotnet_etcd
         /// <returns>The response received from the server.</returns>
         public async Task<MemberAddResponse> MemberAddAsync(MemberAddRequest request, Grpc.Core.Metadata headers = null,
             DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection._clusterClient
+            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection.ClusterClient
                                                                             .MemberAddAsync(request, headers, deadline, cancellationToken)).ConfigureAwait(false);
 
         /// <summary>
@@ -47,7 +47,7 @@ namespace dotnet_etcd
         /// <returns>The response received from the server.</returns>
         public MemberRemoveResponse MemberRemove(MemberRemoveRequest request, Grpc.Core.Metadata headers = null,
             DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection._clusterClient
+            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection.ClusterClient
                                                                             .MemberRemove(request, headers, deadline, cancellationToken));
 
         /// <summary>
@@ -60,7 +60,7 @@ namespace dotnet_etcd
         /// <returns>The response received from the server.</returns>
         public async Task<MemberRemoveResponse> MemberRemoveAsync(MemberRemoveRequest request,
             Grpc.Core.Metadata headers = null, DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection._clusterClient
+            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection.ClusterClient
                                                                             .MemberRemoveAsync(request, headers, deadline, cancellationToken)).ConfigureAwait(false);
 
         /// <summary>
@@ -73,7 +73,7 @@ namespace dotnet_etcd
         /// <returns>The response received from the server.</returns>
         public MemberUpdateResponse MemberUpdate(MemberUpdateRequest request, Grpc.Core.Metadata headers = null,
             DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection._clusterClient
+            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection.ClusterClient
                                                                             .MemberUpdate(request, headers, deadline, cancellationToken));
 
         /// <summary>
@@ -86,7 +86,7 @@ namespace dotnet_etcd
         /// <returns>The response received from the server.</returns>
         public async Task<MemberUpdateResponse> MemberUpdateAsync(MemberUpdateRequest request,
             Grpc.Core.Metadata headers = null, DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection._clusterClient
+            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection.ClusterClient
                                                                             .MemberUpdateAsync(request, headers, deadline, cancellationToken)).ConfigureAwait(false);
 
         /// <summary>
@@ -99,7 +99,7 @@ namespace dotnet_etcd
         /// <returns>The response received from the server.</returns>
         public MemberListResponse MemberList(MemberListRequest request, Grpc.Core.Metadata headers = null,
             DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection._clusterClient
+            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection.ClusterClient
                                                                             .MemberList(request, headers, deadline, cancellationToken));
 
         /// <summary>
@@ -112,7 +112,7 @@ namespace dotnet_etcd
         /// <returns>The response received from the server.</returns>
         public async Task<MemberListResponse> MemberListAsync(MemberListRequest request,
             Grpc.Core.Metadata headers = null, DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection._clusterClient
+            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection.ClusterClient
                                                                             .MemberListAsync(request, headers, deadline, cancellationToken)).ConfigureAwait(false);
     }
 }

--- a/dotnet-etcd/electionClient.cs
+++ b/dotnet-etcd/electionClient.cs
@@ -31,7 +31,7 @@ namespace dotnet_etcd
             Metadata headers = null,
             DateTime? deadline = null,
             CancellationToken cancellationToken = default)
-            => CallEtcd((connection) => connection._electionClient.Campaign(
+            => CallEtcd((connection) => connection.ElectionClient.Campaign(
 #pragma warning disable S3928 // Parameter names used into ArgumentException constructors should match an existing one
                 request ?? throw new ArgumentNullException(nameof(request)),
 #pragma warning restore S3928 // Parameter names used into ArgumentException constructors should match an existing one
@@ -57,7 +57,7 @@ namespace dotnet_etcd
             Metadata headers = null,
             DateTime? deadline = null,
             CancellationToken cancellationToken = default)
-            => CallEtcd((connection) => connection._electionClient.Campaign(
+            => CallEtcd((connection) => connection.ElectionClient.Campaign(
                 new CampaignRequest() {
 #pragma warning disable S3928 // Parameter names used into ArgumentException constructors should match an existing one
                     Name = ByteString.CopyFromUtf8(name ?? throw new ArgumentNullException(nameof(name))),
@@ -84,7 +84,7 @@ namespace dotnet_etcd
             Metadata headers = null,
             DateTime? deadline = null,
             CancellationToken cancellationToken = default)
-            => await CallEtcdAsync(async (connection) => await connection._electionClient.CampaignAsync(
+            => await CallEtcdAsync(async (connection) => await connection.ElectionClient.CampaignAsync(
 #pragma warning disable S3928 // Parameter names used into ArgumentException constructors should match an existing one
                 request ?? throw new ArgumentNullException(nameof(request)),
 #pragma warning restore S3928 // Parameter names used into ArgumentException constructors should match an existing one
@@ -110,7 +110,7 @@ namespace dotnet_etcd
             Metadata headers = null,
             DateTime? deadline = null,
             CancellationToken cancellationToken = default)
-            => await CallEtcdAsync(async (connection) => await connection._electionClient.CampaignAsync(
+            => await CallEtcdAsync(async (connection) => await connection.ElectionClient.CampaignAsync(
                 new CampaignRequest()
                 {
 #pragma warning disable S3928 // Parameter names used into ArgumentException constructors should match an existing one
@@ -135,7 +135,7 @@ namespace dotnet_etcd
             Metadata headers = null,
             DateTime? deadline = null,
             CancellationToken cancellationToken = default)
-            => CallEtcd((connection) => connection._electionClient.Proclaim(
+            => CallEtcd((connection) => connection.ElectionClient.Proclaim(
 #pragma warning disable S3928 // Parameter names used into ArgumentException constructors should match an existing one
                 request ?? throw new ArgumentNullException(nameof(request)),
 #pragma warning restore S3928 // Parameter names used into ArgumentException constructors should match an existing one
@@ -158,7 +158,7 @@ namespace dotnet_etcd
             Metadata headers = null,
             DateTime? deadline = null,
             CancellationToken cancellationToken = default)
-            => CallEtcd((connection) => connection._electionClient.Proclaim(
+            => CallEtcd((connection) => connection.ElectionClient.Proclaim(
                 new ProclaimRequest
                 {
 #pragma warning disable S3928 // Parameter names used into ArgumentException constructors should match an existing one
@@ -183,7 +183,7 @@ namespace dotnet_etcd
             Metadata headers = null,
             DateTime? deadline = null,
             CancellationToken cancellationToken = default)
-            => await CallEtcdAsync(async (connection) => await connection._electionClient.ProclaimAsync(
+            => await CallEtcdAsync(async (connection) => await connection.ElectionClient.ProclaimAsync(
 #pragma warning disable S3928 // Parameter names used into ArgumentException constructors should match an existing one
                 request ?? throw new ArgumentNullException(nameof(request)),
 #pragma warning restore S3928 // Parameter names used into ArgumentException constructors should match an existing one
@@ -206,7 +206,7 @@ namespace dotnet_etcd
             Metadata headers = null,
             DateTime? deadline = null,
             CancellationToken cancellationToken = default)
-            => await CallEtcdAsync(async (connection) => await connection._electionClient.ProclaimAsync(
+            => await CallEtcdAsync(async (connection) => await connection.ElectionClient.ProclaimAsync(
                 new ProclaimRequest
                 {
 #pragma warning disable S3928 // Parameter names used into ArgumentException constructors should match an existing one
@@ -231,7 +231,7 @@ namespace dotnet_etcd
             Metadata headers = null,
             DateTime? deadline = null,
             CancellationToken cancellationToken = default)
-            => CallEtcd((connection) => connection._electionClient.Leader(
+            => CallEtcd((connection) => connection.ElectionClient.Leader(
 #pragma warning disable S3928 // Parameter names used into ArgumentException constructors should match an existing one
                 request ?? throw new ArgumentNullException(nameof(request)),
 #pragma warning restore S3928 // Parameter names used into ArgumentException constructors should match an existing one
@@ -252,7 +252,7 @@ namespace dotnet_etcd
             Metadata headers = null,
             DateTime? deadline = null,
             CancellationToken cancellationToken = default)
-            => CallEtcd((connection) => connection._electionClient.Leader(
+            => CallEtcd((connection) => connection.ElectionClient.Leader(
                 new LeaderRequest
                 {
 #pragma warning disable S3928 // Parameter names used into ArgumentException constructors should match an existing one
@@ -276,7 +276,7 @@ namespace dotnet_etcd
             Metadata headers = null,
             DateTime? deadline = null,
             CancellationToken cancellationToken = default)
-            => await CallEtcdAsync(async (connection) => await connection._electionClient.LeaderAsync(
+            => await CallEtcdAsync(async (connection) => await connection.ElectionClient.LeaderAsync(
 #pragma warning disable S3928 // Parameter names used into ArgumentException constructors should match an existing one
                 request ?? throw new ArgumentNullException(nameof(request)),
 #pragma warning restore S3928 // Parameter names used into ArgumentException constructors should match an existing one
@@ -297,7 +297,7 @@ namespace dotnet_etcd
             Metadata headers = null,
             DateTime? deadline = null,
             CancellationToken cancellationToken = default)
-            => await CallEtcdAsync(async (connection) => await connection._electionClient.LeaderAsync(
+            => await CallEtcdAsync(async (connection) => await connection.ElectionClient.LeaderAsync(
                 new LeaderRequest
                 {
 #pragma warning disable S3928 // Parameter names used into ArgumentException constructors should match an existing one
@@ -322,7 +322,7 @@ namespace dotnet_etcd
             Metadata headers = null,
             DateTime? deadline = null,
             CancellationToken cancellationToken = default)
-            => CallEtcd((connection) => connection._electionClient.Observe(
+            => CallEtcd((connection) => connection.ElectionClient.Observe(
 #pragma warning disable S3928 // Parameter names used into ArgumentException constructors should match an existing one
                 request ?? throw new ArgumentNullException(nameof(request)),
 #pragma warning restore S3928 // Parameter names used into ArgumentException constructors should match an existing one
@@ -344,7 +344,7 @@ namespace dotnet_etcd
             Metadata headers = null,
             DateTime? deadline = null,
             CancellationToken cancellationToken = default)
-            => CallEtcd((connection) => connection._electionClient.Observe(
+            => CallEtcd((connection) => connection.ElectionClient.Observe(
                 new LeaderRequest
                 {
 #pragma warning disable S3928 // Parameter names used into ArgumentException constructors should match an existing one
@@ -370,7 +370,7 @@ namespace dotnet_etcd
             DateTime? deadline = null,
             [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
-            using (AsyncServerStreamingCall<LeaderResponse> leaderResponse = _connection._electionClient.Observe(
+            using (AsyncServerStreamingCall<LeaderResponse> leaderResponse = _connection.ElectionClient.Observe(
                 request ?? throw new ArgumentNullException(nameof(request)),
                 headers,
                 deadline,
@@ -398,7 +398,7 @@ namespace dotnet_etcd
             DateTime? deadline = null,
             [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
-            using (AsyncServerStreamingCall<LeaderResponse> leaderResponse = _connection._electionClient.Observe(
+            using (AsyncServerStreamingCall<LeaderResponse> leaderResponse = _connection.ElectionClient.Observe(
                 new LeaderRequest
                 {
                     Name = ByteString.CopyFromUtf8(name ?? throw new ArgumentNullException(nameof(name)))
@@ -428,7 +428,7 @@ namespace dotnet_etcd
             Metadata headers = null,
             DateTime? deadline = null,
             CancellationToken cancellationToken = default)
-            => CallEtcd((connection) => connection._electionClient.Resign(
+            => CallEtcd((connection) => connection.ElectionClient.Resign(
 #pragma warning disable S3928 // Parameter names used into ArgumentException constructors should match an existing one
                 request ?? throw new ArgumentNullException(nameof(request)),
 #pragma warning restore S3928 // Parameter names used into ArgumentException constructors should match an existing one
@@ -450,7 +450,7 @@ namespace dotnet_etcd
             Metadata headers = null,
             DateTime? deadline = null,
             CancellationToken cancellationToken = default)
-            => CallEtcd((connection) => connection._electionClient.Resign(
+            => CallEtcd((connection) => connection.ElectionClient.Resign(
                 new ResignRequest
                 {
 #pragma warning disable S3928 // Parameter names used into ArgumentException constructors should match an existing one
@@ -475,7 +475,7 @@ namespace dotnet_etcd
             Metadata headers = null,
             DateTime? deadline = null,
             CancellationToken cancellationToken = default)
-            => await CallEtcdAsync(async (connection) => await connection._electionClient.ResignAsync(
+            => await CallEtcdAsync(async (connection) => await connection.ElectionClient.ResignAsync(
 #pragma warning disable S3928 // Parameter names used into ArgumentException constructors should match an existing one
                 request ?? throw new ArgumentNullException(nameof(request)),
 #pragma warning restore S3928 // Parameter names used into ArgumentException constructors should match an existing one
@@ -497,7 +497,7 @@ namespace dotnet_etcd
             Metadata headers = null,
             DateTime? deadline = null,
             CancellationToken cancellationToken = default)
-            => await CallEtcdAsync(async (connection) => await connection._electionClient.ResignAsync(
+            => await CallEtcdAsync(async (connection) => await connection.ElectionClient.ResignAsync(
                 new ResignRequest
                 {
 #pragma warning disable S3928 // Parameter names used into ArgumentException constructors should match an existing one

--- a/dotnet-etcd/etcdClient.cs
+++ b/dotnet-etcd/etcdClient.cs
@@ -66,6 +66,11 @@ namespace dotnet_etcd
 
         #region Initializers
 
+        public EtcdClient(CallInvoker callInvoker)
+        {
+            _connection = new Connection(callInvoker ?? throw new ArgumentNullException(nameof(callInvoker)));
+        }
+
         public EtcdClient(string connectionString, int port = 2379, string serverName = DefaultServerName, Action<GrpcChannelOptions> configureChannelOptions = null, Interceptor[] interceptors = null)
         {
 
@@ -137,17 +142,7 @@ namespace dotnet_etcd
 
 
             // Setup Connection
-            _connection = new Connection
-            {
-                _kvClient = new KV.KVClient(callInvoker),
-                _watchClient = new Watch.WatchClient(callInvoker),
-                _leaseClient = new Lease.LeaseClient(callInvoker),
-                _lockClient = new V3Lockpb.Lock.LockClient(callInvoker),
-                _clusterClient = new Cluster.ClusterClient(callInvoker),
-                _maintenanceClient = new Maintenance.MaintenanceClient(callInvoker),
-                _authClient = new Auth.AuthClient(callInvoker),
-                _electionClient = new V3Electionpb.Election.ElectionClient(callInvoker)
-            };
+            _connection = new Connection(callInvoker);
         }
 
         #endregion

--- a/dotnet-etcd/etcdClient.cs
+++ b/dotnet-etcd/etcdClient.cs
@@ -5,13 +5,10 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Net.Http;
 
 
 using dotnet_etcd.interfaces;
 using dotnet_etcd.multiplexer;
-
-using Etcdserverpb;
 
 using Grpc.Core;
 using Grpc.Core.Interceptors;

--- a/dotnet-etcd/interfaces/IEtcdClient.cs
+++ b/dotnet-etcd/interfaces/IEtcdClient.cs
@@ -57,6 +57,7 @@ namespace dotnet_etcd.interfaces
         Task LeaseKeepAlive(LeaseKeepAliveRequest request, Action<LeaseKeepAliveResponse>[] methods, CancellationToken cancellationToken, Grpc.Core.Metadata headers = null);
         Task LeaseKeepAlive(LeaseKeepAliveRequest[] requests, Action<LeaseKeepAliveResponse> method, CancellationToken cancellationToken, Grpc.Core.Metadata headers = null);
         Task LeaseKeepAlive(LeaseKeepAliveRequest[] requests, Action<LeaseKeepAliveResponse>[] methods, CancellationToken cancellationToken, Grpc.Core.Metadata headers = null, DateTime? deadline = null);
+        Task LeaseKeepAlive(CancellationTokenSource cancellationTokenSource, long leaseId, int keepAliveTimeout = 1000, int? communicationTimeout = null, Grpc.Core.Metadata headers = null, DateTime? deadline = null);
         Task LeaseKeepAlive(long leaseId, CancellationToken cancellationToken);
         LeaseRevokeResponse LeaseRevoke(LeaseRevokeRequest request, Grpc.Core.Metadata headers = null, DateTime? deadline = null, CancellationToken cancellationToken = default);
         Task<LeaseRevokeResponse> LeaseRevokeAsync(LeaseRevokeRequest request, Grpc.Core.Metadata headers = null, DateTime? deadline = null, CancellationToken cancellationToken = default);

--- a/dotnet-etcd/kvClient.cs
+++ b/dotnet-etcd/kvClient.cs
@@ -23,7 +23,7 @@ namespace dotnet_etcd
         /// <param name="cancellationToken">An optional token for canceling the call.</param>
         /// <returns>The etcd response for the specified request</returns>
         public RangeResponse Get(RangeRequest request, Grpc.Core.Metadata headers = null, DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection._kvClient
+            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection.KVClient
                                                                             .Range(request, headers, deadline, cancellationToken));
 
         /// <summary>
@@ -50,7 +50,7 @@ namespace dotnet_etcd
         /// <returns>The etcd response for the specified request</returns>
         public async Task<RangeResponse> GetAsync(RangeRequest request, Grpc.Core.Metadata headers = null,
             DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection._kvClient
+            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection.KVClient
                                                                             .RangeAsync(request, headers, deadline, cancellationToken)).ConfigureAwait(false);
 
         /// <summary>
@@ -186,7 +186,7 @@ namespace dotnet_etcd
         /// <param name="cancellationToken">An optional token for canceling the call.</param>
         /// <returns>The response received from the server.</returns>
         public PutResponse Put(PutRequest request, Grpc.Core.Metadata headers = null, DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection._kvClient.Put(request, headers, deadline, cancellationToken));
+            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection.KVClient.Put(request, headers, deadline, cancellationToken));
 
         /// <summary>
         /// Sets the key value in etcd
@@ -214,7 +214,7 @@ namespace dotnet_etcd
         /// <returns>The response received from the server.</returns>
         public async Task<PutResponse> PutAsync(PutRequest request, Grpc.Core.Metadata headers = null,
             DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection._kvClient
+            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection.KVClient
                                                                             .PutAsync(request, headers, deadline, cancellationToken)).ConfigureAwait(false);
 
 
@@ -245,7 +245,7 @@ namespace dotnet_etcd
         /// <returns>The response received from the server.</returns>
         public DeleteRangeResponse Delete(DeleteRangeRequest request, Grpc.Core.Metadata headers = null,
             DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection._kvClient
+            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection.KVClient
                                                                             .DeleteRange(request, headers, deadline, cancellationToken));
 
         /// <summary>
@@ -273,7 +273,7 @@ namespace dotnet_etcd
         /// <returns>The response received from the server.</returns>
         public async Task<DeleteRangeResponse> DeleteAsync(DeleteRangeRequest request,
             Grpc.Core.Metadata headers = null, DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection._kvClient
+            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection.KVClient
                                                                             .DeleteRangeAsync(request, headers, deadline, cancellationToken)).ConfigureAwait(false);
 
         /// <summary>
@@ -343,7 +343,7 @@ namespace dotnet_etcd
         /// <param name="cancellationToken">An optional token for canceling the call.</param>
         /// <returns>The response received from the server.</returns>
         public TxnResponse Transaction(TxnRequest request, Grpc.Core.Metadata headers = null, DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection._kvClient.Txn(request, headers, deadline, cancellationToken));
+            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection.KVClient.Txn(request, headers, deadline, cancellationToken));
 
         /// <summary>
         ///  Txn processes multiple requests in a single transaction in async.
@@ -358,7 +358,7 @@ namespace dotnet_etcd
         /// <returns>The response received from the server.</returns>
         public async Task<TxnResponse> TransactionAsync(TxnRequest request, Grpc.Core.Metadata headers = null,
             DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection._kvClient
+            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection.KVClient
                                                                             .TxnAsync(request, headers, deadline, cancellationToken)).ConfigureAwait(false);
 
         /// <summary>
@@ -373,7 +373,7 @@ namespace dotnet_etcd
         /// <returns>The response received from the server.</returns>
         public CompactionResponse Compact(CompactionRequest request, Grpc.Core.Metadata headers = null,
             DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection._kvClient
+            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection.KVClient
                                                                             .Compact(request, headers, deadline, cancellationToken));
 
         /// <summary>
@@ -388,7 +388,7 @@ namespace dotnet_etcd
         /// <returns>The response received from the server.</returns>
         public async Task<CompactionResponse> CompactAsync(CompactionRequest request, Grpc.Core.Metadata headers = null,
             DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection._kvClient
+            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection.KVClient
                                                                             .CompactAsync(request, headers, deadline, cancellationToken)).ConfigureAwait(false);
     }
 }

--- a/dotnet-etcd/leaseClient.cs
+++ b/dotnet-etcd/leaseClient.cs
@@ -26,7 +26,7 @@ namespace dotnet_etcd
         /// <returns>The response received from the server.</returns>
         public LeaseGrantResponse LeaseGrant(LeaseGrantRequest request, Grpc.Core.Metadata headers = null,
             DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection._leaseClient
+            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection.LeaseClient
                                                                             .LeaseGrant(request, headers, deadline, cancellationToken));
 
         /// <summary>
@@ -41,7 +41,7 @@ namespace dotnet_etcd
         /// <returns>The response received from the server.</returns>
         public async Task<LeaseGrantResponse> LeaseGrantAsync(LeaseGrantRequest request,
             Grpc.Core.Metadata headers = null, DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection._leaseClient
+            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection.LeaseClient
                                                                             .LeaseGrantAsync(request, headers, deadline, cancellationToken)).ConfigureAwait(false);
 
         /// <summary>
@@ -54,7 +54,7 @@ namespace dotnet_etcd
         /// <returns>The response received from the server.</returns>
         public LeaseRevokeResponse LeaseRevoke(LeaseRevokeRequest request, Grpc.Core.Metadata headers = null,
             DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection._leaseClient
+            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection.LeaseClient
                                                                             .LeaseRevoke(request, headers, deadline, cancellationToken));
 
         /// <summary>
@@ -67,7 +67,7 @@ namespace dotnet_etcd
         /// <returns>The response received from the server.</returns>
         public async Task<LeaseRevokeResponse> LeaseRevokeAsync(LeaseRevokeRequest request,
             Grpc.Core.Metadata headers = null, DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection._leaseClient
+            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection.LeaseClient
                                                                             .LeaseRevokeAsync(request, headers, deadline, cancellationToken)).ConfigureAwait(false);
 
         /// <summary>
@@ -79,7 +79,7 @@ namespace dotnet_etcd
         public async Task LeaseKeepAlive(long leaseId, CancellationToken cancellationToken) => await CallEtcdAsync(async (connection) =>
                                                                                              {
                                                                                                  using (AsyncDuplexStreamingCall<LeaseKeepAliveRequest, LeaseKeepAliveResponse> leaser =
-                                                                                                     connection._leaseClient.LeaseKeepAlive(cancellationToken: cancellationToken))
+                                                                                                     connection.LeaseClient.LeaseKeepAlive(cancellationToken: cancellationToken))
                                                                                                  {
                                                                                                      LeaseKeepAliveRequest request = new()
                                                                                                      {
@@ -121,7 +121,7 @@ namespace dotnet_etcd
             CancellationToken cancellationToken, Grpc.Core.Metadata headers = null) => await CallEtcdAsync(async (connection) =>
                                                                                      {
                                                                                          using (AsyncDuplexStreamingCall<LeaseKeepAliveRequest, LeaseKeepAliveResponse> leaser =
-                                                                                             connection._leaseClient
+                                                                                             connection.LeaseClient
                                                                                                  .LeaseKeepAlive(headers, cancellationToken: cancellationToken))
                                                                                          {
                                                                                              Task leaserTask = Task.Run(async () =>
@@ -151,7 +151,7 @@ namespace dotnet_etcd
             CancellationToken cancellationToken, Grpc.Core.Metadata headers = null) => await CallEtcdAsync(async (connection) =>
                                                                                      {
                                                                                          using (AsyncDuplexStreamingCall<LeaseKeepAliveRequest, LeaseKeepAliveResponse> leaser =
-                                                                                             connection._leaseClient
+                                                                                             connection.LeaseClient
                                                                                                  .LeaseKeepAlive(headers, cancellationToken: cancellationToken))
                                                                                          {
                                                                                              Task leaserTask = Task.Run(async () =>
@@ -186,7 +186,7 @@ namespace dotnet_etcd
             CancellationToken cancellationToken, Grpc.Core.Metadata headers = null) => await CallEtcdAsync(async (connection) =>
                                                                                      {
                                                                                          using (AsyncDuplexStreamingCall<LeaseKeepAliveRequest, LeaseKeepAliveResponse> leaser =
-                                                                                             connection._leaseClient
+                                                                                             connection.LeaseClient
                                                                                                  .LeaseKeepAlive(headers, cancellationToken: cancellationToken))
                                                                                          {
                                                                                              Task leaserTask = Task.Run(async () =>
@@ -221,7 +221,7 @@ namespace dotnet_etcd
             CancellationToken cancellationToken, Grpc.Core.Metadata headers = null, DateTime? deadline = null) => await CallEtcdAsync(async (connection) =>
                                                                                                                 {
                                                                                                                     using (AsyncDuplexStreamingCall<LeaseKeepAliveRequest, LeaseKeepAliveResponse> leaser =
-                                                                                                                        connection._leaseClient
+                                                                                                                        connection.LeaseClient
                                                                                                                             .LeaseKeepAlive(headers, deadline, cancellationToken))
                                                                                                                     {
                                                                                                                         Task leaserTask = Task.Run(async () =>
@@ -257,7 +257,7 @@ namespace dotnet_etcd
         /// <returns>The response received from the server.</returns>
         public LeaseTimeToLiveResponse LeaseTimeToLive(LeaseTimeToLiveRequest request,
             Grpc.Core.Metadata headers = null, DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection._leaseClient
+            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection.LeaseClient
                                                                             .LeaseTimeToLive(request, headers, deadline, cancellationToken));
 
         /// <summary>
@@ -270,7 +270,7 @@ namespace dotnet_etcd
         /// <returns>The call object.</returns>
         public async Task<LeaseTimeToLiveResponse> LeaseTimeToLiveAsync(LeaseTimeToLiveRequest request,
             Grpc.Core.Metadata headers = null, DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection._leaseClient
+            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection.LeaseClient
                                                                             .LeaseTimeToLiveAsync(request, headers, deadline, cancellationToken)).ConfigureAwait(false);
     }
 }

--- a/dotnet-etcd/leaseClient.cs
+++ b/dotnet-etcd/leaseClient.cs
@@ -74,40 +74,189 @@ namespace dotnet_etcd
         /// LeaseKeepAlive keeps the lease alive by streaming keep alive requests from the client
         /// to the server and streaming keep alive responses from the server to the client.
         /// </summary>
+        /// <param name="cancellationTokenSource">Cancellation token source that reflects communication status between server and client.</param>
+        /// <param name="leaseId">Granted lease identifier. <see cref="LeaseGrant"/> and <see cref="LeaseGrantAsync"/></param>
+        /// <param name="keepAliveTimeout">Time to the next communication with Etcd server in milliseconds.</param>
+        /// <param name="communicationTimeout">Time to wait response from Etcd server in milliseconds.</param>
+        /// <param name="headers">The initial metadata to send with the call. This parameter is optional.</param>
+        /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
+        public Task LeaseKeepAlive(CancellationTokenSource cancellationTokenSource, long leaseId, int keepAliveTimeout = 1000, int? communicationTimeout = null, Metadata headers = null, DateTime? deadline = null) => CallEtcdAsync((connection) =>
+        {
+            ArgumentNullException.ThrowIfNull(cancellationTokenSource);
+#pragma warning disable CA1512 // ArgumentOutOfRangeException.ThrowIfNegativeOrZero it is only .NET 8 now
+            if (keepAliveTimeout <= 0)
+            {   
+                throw new ArgumentOutOfRangeException(nameof(keepAliveTimeout));
+            }
+#pragma warning restore CA1512
+            if (communicationTimeout != null && communicationTimeout <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(communicationTimeout));
+            }
+
+            CancellationToken cancellationToken = cancellationTokenSource.Token;
+
+            async ValueTask WriteAsync(AsyncDuplexStreamingCall<LeaseKeepAliveRequest, LeaseKeepAliveResponse> leaser, LeaseKeepAliveRequest request, int timeoutInMilliseconds, CancellationToken cancellationToken)
+            {
+                // communication timeout
+                using CancellationTokenSource cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                cancellationTokenSource.CancelAfter(timeoutInMilliseconds);
+
+                await leaser.RequestStream.WriteAsync(request, cancellationTokenSource.Token)
+                    .ConfigureAwait(false);
+            }
+
+            async ValueTask<bool> MoveNextAsync(AsyncDuplexStreamingCall<LeaseKeepAliveRequest, LeaseKeepAliveResponse> leaser, int timeoutInMilliseconds, CancellationToken cancellationToken)
+            {
+                // communication timeout
+                using CancellationTokenSource cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                cancellationTokenSource.CancelAfter(timeoutInMilliseconds);
+
+                return await leaser.ResponseStream.MoveNext(cancellationTokenSource.Token)
+                    .ConfigureAwait(false);
+            }
+
+            AsyncDuplexStreamingCall<LeaseKeepAliveRequest, LeaseKeepAliveResponse> LeaseKeepAlive(Connection connection, int timeoutInMilliseconds, CancellationToken cancellationToken)
+            {
+                // communication timeout
+                using CancellationTokenSource cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                cancellationTokenSource.CancelAfter(timeoutInMilliseconds);
+
+                return connection.LeaseClient.LeaseKeepAlive(headers, deadline, cancellationTokenSource.Token);
+            }
+
+            async Task KeepAliveAsync()
+            {
+                int communicationTimeoutInMilliseconds = communicationTimeout ?? keepAliveTimeout / 2;
+                LeaseKeepAliveRequest request = new()
+                {
+                    ID = leaseId,
+                };
+
+                try
+                {
+                    using AsyncDuplexStreamingCall<LeaseKeepAliveRequest, LeaseKeepAliveResponse> leaser =
+                        LeaseKeepAlive(connection, communicationTimeoutInMilliseconds, cancellationToken);
+
+                    while (!cancellationToken.IsCancellationRequested)
+                    {
+                        await WriteAsync(leaser, request, communicationTimeoutInMilliseconds, cancellationToken)
+                            .ConfigureAwait(false);
+
+                        if (!await MoveNextAsync(leaser, communicationTimeoutInMilliseconds, cancellationToken)
+                                .ConfigureAwait(false))
+                        {
+                            try
+                            {
+                                if (!cancellationTokenSource.IsCancellationRequested)
+                                {
+#if NET8_0_OR_GREATER
+                                    await cancellationTokenSource.CancelAsync()
+                                        .ConfigureAwait(false);
+#else
+                                        cancellationTokenSource.Cancel();
+#endif
+                                }
+                            }
+                            finally
+                            {
+                                await leaser.RequestStream.CompleteAsync()
+                                    .ConfigureAwait(false);
+                            }
+
+                            break;
+                        }
+
+                        LeaseKeepAliveResponse update = leaser.ResponseStream.Current;
+                        if (update.ID != leaseId || update.TTL == 0) // expired
+                        {
+                            try
+                            {
+                                if (!cancellationTokenSource.IsCancellationRequested)
+                                {
+#if NET8_0_OR_GREATER
+                                    await cancellationTokenSource.CancelAsync()
+                                        .ConfigureAwait(false);
+#else
+                                        cancellationTokenSource.Cancel();
+#endif
+                                }
+                            }
+                            finally
+                            {
+                                await leaser.RequestStream.CompleteAsync()
+                                    .ConfigureAwait(false);
+                            }
+
+                            break;
+                        }
+
+                        await Task.Delay(keepAliveTimeout, cancellationToken)
+                            .ConfigureAwait(false);
+                    }
+                }
+                finally
+                {
+                    if (!cancellationTokenSource.IsCancellationRequested)
+                    {
+
+#if NET8_0_OR_GREATER
+                        await cancellationTokenSource.CancelAsync()
+                            .ConfigureAwait(false);
+#else
+                            cancellationTokenSource.Cancel();
+#endif
+                    }
+                }
+            }
+
+            return Task.Factory.StartNew(
+                (_) => KeepAliveAsync(),
+                null,
+                cancellationToken,
+                TaskCreationOptions.LongRunning,
+                TaskScheduler.Current)
+                .Unwrap();
+        });
+
+        /// <summary>
+        /// LeaseKeepAlive keeps the lease alive by streaming keep alive requests from the client
+        /// to the server and streaming keep alive responses from the server to the client.
+        /// </summary>
         /// <param name="leaseId"></param>
         /// <param name="cancellationToken"></param>
         public async Task LeaseKeepAlive(long leaseId, CancellationToken cancellationToken) => await CallEtcdAsync(async (connection) =>
-                                                                                             {
-                                                                                                 using (AsyncDuplexStreamingCall<LeaseKeepAliveRequest, LeaseKeepAliveResponse> leaser =
-                                                                                                     connection.LeaseClient.LeaseKeepAlive(cancellationToken: cancellationToken))
-                                                                                                 {
-                                                                                                     LeaseKeepAliveRequest request = new()
-                                                                                                     {
-                                                                                                         ID = leaseId
-                                                                                                     };
+        {
+            using (AsyncDuplexStreamingCall<LeaseKeepAliveRequest, LeaseKeepAliveResponse> leaser =
+                connection.LeaseClient.LeaseKeepAlive(cancellationToken: cancellationToken))
+            {
+                LeaseKeepAliveRequest request = new()
+                {
+                    ID = leaseId
+                };
 
-                                                                                                     while (true)
-                                                                                                     {
-                                                                                                         cancellationToken.ThrowIfCancellationRequested();
+                while (true)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
 
-                                                                                                         await leaser.RequestStream.WriteAsync(request).ConfigureAwait(false);
-                                                                                                         if (!await leaser.ResponseStream.MoveNext(cancellationToken).ConfigureAwait(false))
-                                                                                                         {
-                                                                                                             await leaser.RequestStream.CompleteAsync().ConfigureAwait(false);
-                                                                                                             throw new EndOfStreamException();
-                                                                                                         }
+                    await leaser.RequestStream.WriteAsync(request).ConfigureAwait(false);
+                    if (!await leaser.ResponseStream.MoveNext(cancellationToken).ConfigureAwait(false))
+                    {
+                        await leaser.RequestStream.CompleteAsync().ConfigureAwait(false);
+                        throw new EndOfStreamException();
+                    }
 
-                                                                                                         LeaseKeepAliveResponse update = leaser.ResponseStream.Current;
-                                                                                                         if (update.ID != leaseId || update.TTL == 0) // expired
-                                                                                                         {
-                                                                                                             await leaser.RequestStream.CompleteAsync().ConfigureAwait(false);
-                                                                                                             return;
-                                                                                                         }
+                    LeaseKeepAliveResponse update = leaser.ResponseStream.Current;
+                    if (update.ID != leaseId || update.TTL == 0) // expired
+                    {
+                        await leaser.RequestStream.CompleteAsync().ConfigureAwait(false);
+                        return;
+                    }
 
-                                                                                                         await Task.Delay(TimeSpan.FromMilliseconds(update.TTL * 1000 / 3), cancellationToken).ConfigureAwait(false);
-                                                                                                     }
-                                                                                                 }
-                                                                                             }).ConfigureAwait(false);
+                    await Task.Delay(TimeSpan.FromMilliseconds(update.TTL * 1000 / 3), cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }).ConfigureAwait(false);
 
         /// <summary>
         /// LeaseKeepAlive keeps the lease alive by streaming keep alive requests from the client

--- a/dotnet-etcd/leaseClient.cs
+++ b/dotnet-etcd/leaseClient.cs
@@ -116,7 +116,7 @@ namespace dotnet_etcd
                     .ConfigureAwait(false);
             }
 
-            AsyncDuplexStreamingCall<LeaseKeepAliveRequest, LeaseKeepAliveResponse> LeaseKeepAlive(Connection connection, int timeoutInMilliseconds, CancellationToken cancellationToken)
+            AsyncDuplexStreamingCall<LeaseKeepAliveRequest, LeaseKeepAliveResponse> LeaseKeepAlive(multiplexer.Connection connection, int timeoutInMilliseconds, CancellationToken cancellationToken)
             {
                 // communication timeout
                 using CancellationTokenSource cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);

--- a/dotnet-etcd/lockClient.cs
+++ b/dotnet-etcd/lockClient.cs
@@ -46,7 +46,7 @@ namespace dotnet_etcd
         /// <param name="cancellationToken">An optional token for canceling the call.</param>
         /// <returns>The response received from the server.</returns>
         public LockResponse Lock(LockRequest request, Grpc.Core.Metadata headers = null, DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection._lockClient.Lock(request, headers, deadline, cancellationToken));
+            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection.LockClient.Lock(request, headers, deadline, cancellationToken));
 
         /// <summary>
         /// LockAsync acquires a distributed shared lock on a given named lock.
@@ -81,7 +81,7 @@ namespace dotnet_etcd
         /// <param name="cancellationToken">An optional token for canceling the call.</param>
         /// <returns>The response received from the server.</returns>
         public async Task<LockResponse> LockAsync(LockRequest request, Grpc.Core.Metadata headers = null,
-            DateTime? deadline = null, CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection._lockClient
+            DateTime? deadline = null, CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection.LockClient
                                                                                                        .LockAsync(request, headers, deadline, cancellationToken)).ConfigureAwait(false);
 
         /// <summary>
@@ -111,7 +111,7 @@ namespace dotnet_etcd
         /// <param name="cancellationToken">An optional token for canceling the call.</param>
         /// <returns>The response received from the server.</returns>
         public UnlockResponse Unlock(UnlockRequest request, Grpc.Core.Metadata headers = null,
-            DateTime? deadline = null, CancellationToken cancellationToken = default) => CallEtcd((connection) => connection._lockClient
+            DateTime? deadline = null, CancellationToken cancellationToken = default) => CallEtcd((connection) => connection.LockClient
                                                                                                        .Unlock(request, headers, deadline, cancellationToken));
 
         /// <summary>
@@ -141,7 +141,7 @@ namespace dotnet_etcd
         /// <param name="cancellationToken">An optional token for canceling the call.</param>
         /// <returns>The response received from the server.</returns>
         public async Task<UnlockResponse> UnlockAsync(UnlockRequest request, Grpc.Core.Metadata headers = null,
-            DateTime? deadline = null, CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection._lockClient
+            DateTime? deadline = null, CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection.LockClient
                                                                                                        .UnlockAsync(request, headers, deadline, cancellationToken)).ConfigureAwait(false);
     }
 }

--- a/dotnet-etcd/maintenanceClient.cs
+++ b/dotnet-etcd/maintenanceClient.cs
@@ -22,7 +22,7 @@ namespace dotnet_etcd
         /// <param name="cancellationToken">An optional token for canceling the call.</param>
         /// <returns>Alarm Response</returns>
         public AlarmResponse Alarm(AlarmRequest request, Grpc.Core.Metadata headers = null, DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection._maintenanceClient
+            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection.MaintenanceClient
                                                                             .Alarm(request, headers, deadline, cancellationToken));
 
         /// <summary>
@@ -35,7 +35,7 @@ namespace dotnet_etcd
         /// <returns>Alarm Response</returns>
         public async Task<AlarmResponse> AlarmAsync(AlarmRequest request, Grpc.Core.Metadata headers = null,
             DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection._maintenanceClient
+            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection.MaintenanceClient
                                                                             .AlarmAsync(request, headers, deadline, cancellationToken)).ConfigureAwait(false);
 
         /// <summary>
@@ -48,7 +48,7 @@ namespace dotnet_etcd
         /// <returns>Status response</returns>
         public StatusResponse Status(StatusRequest request, Grpc.Core.Metadata headers = null,
             DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection._maintenanceClient
+            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection.MaintenanceClient
                                                                             .Status(request, headers, deadline, cancellationToken));
 
         /// <summary>
@@ -61,7 +61,7 @@ namespace dotnet_etcd
         /// <returns>Status response</returns>
         public async Task<StatusResponse> StatusAsync(StatusRequest request, Grpc.Core.Metadata headers = null,
             DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection._maintenanceClient
+            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection.MaintenanceClient
                                                                             .StatusAsync(request, headers, deadline, cancellationToken)).ConfigureAwait(false);
 
         /// <summary>
@@ -74,7 +74,7 @@ namespace dotnet_etcd
         /// <returns>Defragment Response</returns>
         public DefragmentResponse Defragment(DefragmentRequest request, Grpc.Core.Metadata headers = null,
             DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection._maintenanceClient
+            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection.MaintenanceClient
                                                                             .Defragment(request, headers, deadline, cancellationToken));
 
         /// <summary>
@@ -87,7 +87,7 @@ namespace dotnet_etcd
         /// <returns>Defragment Response</returns>
         public async Task<DefragmentResponse> DefragmentAsync(DefragmentRequest request,
             Grpc.Core.Metadata headers = null, DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection._maintenanceClient
+            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection.MaintenanceClient
                                                                             .DefragmentAsync(request, headers, deadline, cancellationToken)).ConfigureAwait(false);
 
         /// <summary>
@@ -104,7 +104,7 @@ namespace dotnet_etcd
         /// <param name="cancellationToken">An optional token for canceling the call.</param>
         /// <returns>Hash Response</returns>
         public HashResponse Hash(HashRequest request, Grpc.Core.Metadata headers = null, DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection._maintenanceClient
+            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection.MaintenanceClient
                                                                             .Hash(request, headers, deadline, cancellationToken));
 
         /// <summary>
@@ -122,7 +122,7 @@ namespace dotnet_etcd
         /// <returns>Hash Response</returns>
         public async Task<HashResponse> HashAsync(HashRequest request, Grpc.Core.Metadata headers = null,
             DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection._maintenanceClient
+            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection.MaintenanceClient
                                                                             .HashAsync(request, headers, deadline, cancellationToken)).ConfigureAwait(false);
 
         /// <summary>
@@ -136,7 +136,7 @@ namespace dotnet_etcd
         /// <returns>HashKV Response</returns>
         public HashKVResponse HashKV(HashKVRequest request, Grpc.Core.Metadata headers = null,
             DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection._maintenanceClient
+            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection.MaintenanceClient
                                                                             .HashKV(request, headers, deadline, cancellationToken));
 
         /// <summary>
@@ -150,7 +150,7 @@ namespace dotnet_etcd
         /// <returns>HashKV Response</returns>
         public async Task<HashKVResponse> HashKVAsync(HashKVRequest request, Grpc.Core.Metadata headers = null,
             DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection._maintenanceClient
+            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection.MaintenanceClient
                                                                             .HashKVAsync(request, headers, deadline, cancellationToken)).ConfigureAwait(false);
 
         /// <summary>
@@ -165,7 +165,7 @@ namespace dotnet_etcd
             CancellationToken cancellationToken, Grpc.Core.Metadata headers = null, DateTime? deadline = null) => await CallEtcdAsync(async (connection) =>
                                                                                                                 {
                                                                                                                     using (AsyncServerStreamingCall<SnapshotResponse> snapshotter = connection
-                                                                                                                        ._maintenanceClient.Snapshot(request, headers, deadline, cancellationToken))
+                                                                                                                        .MaintenanceClient.Snapshot(request, headers, deadline, cancellationToken))
                                                                                                                     {
                                                                                                                         while (await snapshotter.ResponseStream.MoveNext(cancellationToken).ConfigureAwait(false))
                                                                                                                         {
@@ -187,7 +187,7 @@ namespace dotnet_etcd
             CancellationToken cancellationToken, Grpc.Core.Metadata headers = null, DateTime? deadline = null) => await CallEtcdAsync(async (connection) =>
                                                                                                                 {
                                                                                                                     using (AsyncServerStreamingCall<SnapshotResponse> snapshotter = connection
-                                                                                                                        ._maintenanceClient.Snapshot(request, headers, deadline, cancellationToken))
+                                                                                                                        .MaintenanceClient.Snapshot(request, headers, deadline, cancellationToken))
                                                                                                                     {
                                                                                                                         while (await snapshotter.ResponseStream.MoveNext(cancellationToken).ConfigureAwait(false))
                                                                                                                         {
@@ -210,7 +210,7 @@ namespace dotnet_etcd
         /// <returns>MoveLeader Response</returns>
         public MoveLeaderResponse MoveLeader(MoveLeaderRequest request, Grpc.Core.Metadata headers = null,
             DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection._maintenanceClient
+            CancellationToken cancellationToken = default) => CallEtcd((connection) => connection.MaintenanceClient
                                                                             .MoveLeader(request, headers, deadline, cancellationToken));
 
         /// <summary>
@@ -223,7 +223,7 @@ namespace dotnet_etcd
         /// <returns>MoveLeader Response</returns>
         public async Task<MoveLeaderResponse> MoveLeaderAsync(MoveLeaderRequest request,
             Grpc.Core.Metadata headers = null, DateTime? deadline = null,
-            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection._maintenanceClient
+            CancellationToken cancellationToken = default) => await CallEtcdAsync(async (connection) => await connection.MaintenanceClient
                                                                             .MoveLeaderAsync(request, headers, deadline, cancellationToken)).ConfigureAwait(false);
     }
 }

--- a/dotnet-etcd/multiplexer/Connection.cs
+++ b/dotnet-etcd/multiplexer/Connection.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Etcdserverpb;
+using Grpc.Core;
 using V3Electionpb;
 using V3Lockpb;
 
@@ -9,20 +10,43 @@ namespace dotnet_etcd.multiplexer
 {
     internal sealed class Connection
     {
-        internal KV.KVClient _kvClient;
+        private readonly CallInvoker _callInvoker;
 
-        internal Watch.WatchClient _watchClient;
+        internal Connection(CallInvoker callInvoker)
+        {
+            _callInvoker = callInvoker;
+        }
 
-        internal Lease.LeaseClient _leaseClient;
+        private KV.KVClient _kvClient;
 
-        internal Lock.LockClient _lockClient;
+        private Watch.WatchClient _watchClient;
 
-        internal Cluster.ClusterClient _clusterClient;
+        private Lease.LeaseClient _leaseClient;
 
-        internal Maintenance.MaintenanceClient _maintenanceClient;
+        private Lock.LockClient _lockClient;
 
-        internal Auth.AuthClient _authClient;
+        private Cluster.ClusterClient _clusterClient;
 
-        internal Election.ElectionClient _electionClient;
+        private Maintenance.MaintenanceClient _maintenanceClient;
+
+        private Auth.AuthClient _authClient;
+
+        private Election.ElectionClient _electionClient;
+
+        internal KV.KVClient KVClient => _kvClient ??= new KV.KVClient(_callInvoker);
+
+        internal Watch.WatchClient WatchClient => _watchClient ??= new Watch.WatchClient(_callInvoker);
+
+        internal Lease.LeaseClient LeaseClient => _leaseClient ??= new Lease.LeaseClient(_callInvoker);
+
+        internal Lock.LockClient LockClient => _lockClient ??= new Lock.LockClient(_callInvoker);
+
+        internal Cluster.ClusterClient ClusterClient => _clusterClient ??= new Cluster.ClusterClient(_callInvoker);
+
+        internal Maintenance.MaintenanceClient MaintenanceClient => _maintenanceClient ??= new Maintenance.MaintenanceClient(_callInvoker);
+
+        internal Auth.AuthClient AuthClient => _authClient ??= new Auth.AuthClient(_callInvoker);
+
+        internal Election.ElectionClient ElectionClient => _electionClient ??= new Election.ElectionClient(_callInvoker);
     }
 }

--- a/dotnet-etcd/watchClient.cs
+++ b/dotnet-etcd/watchClient.cs
@@ -99,7 +99,7 @@ namespace dotnet_etcd
             CancellationToken cancellationToken = default) => CallEtcdAsync(async (connection) =>
                                                             {
                                                                 using (AsyncDuplexStreamingCall<WatchRequest, WatchResponse> watcher =
-                                                                    connection._watchClient.Watch(headers, deadline, cancellationToken))
+                                                                    connection.WatchClient.Watch(headers, deadline, cancellationToken))
                                                                 {
                                                                     Task watcherTask = Task.Run(async () =>
                                                                     {
@@ -176,7 +176,7 @@ namespace dotnet_etcd
             CancellationToken cancellationToken = default) => CallEtcdAsync(async (connection) =>
                                                             {
                                                                 using (AsyncDuplexStreamingCall<WatchRequest, WatchResponse> watcher =
-                                                                    connection._watchClient.Watch(headers, deadline, cancellationToken))
+                                                                    connection.WatchClient.Watch(headers, deadline, cancellationToken))
                                                                 {
                                                                     Task watcherTask = Task.Run(async () =>
                                                                     {


### PR DESCRIPTION
Hi 
I'm trying to build [a distributed lock](https://github.com/luboid/etcd-distributed-lock) and I need a LeaseKeepAlive method with CancelationTokenSource parameter


- [x] Use the following format: [luboid/dotnet-etcd](https://github.com/luboid/dotnet-etcd)
- [x] Link additions should be added to the bottom of the relevant category.
- [x] New categories or improvements to the existing categorization are welcome.
- [x] Search previous suggestions before making a new one, as yours may be a duplicate.
- [x] Sort by alphabetical order
