### PR TITLE
ci: automated GitHub Releases with generated notes + PR auto-labeling

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,36 @@
+# Configuration for GitHub's automatically generated release notes.
+# Used by the "Create GitHub Release" step (gh release create --generate-notes).
+# Notes are built from pull requests merged since the previous tag and grouped
+# into the categories below by PR label. No manual changelog to maintain.
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+  categories:
+    - title: ⚠️ Breaking Changes
+      labels:
+        - breaking-change
+        - breaking
+    - title: 🚀 Features
+      labels:
+        - enhancement
+        - feature
+    - title: 🐛 Bug Fixes
+      labels:
+        - bug
+        - fix
+    - title: 📦 Dependencies
+      labels:
+        - dependencies
+    - title: 📝 Documentation
+      labels:
+        - documentation
+    - title: 🔧 Maintenance & CI
+      labels:
+        - ci
+        - chore
+        - tests
+    # Catch-all so every other merged PR still appears in the notes.
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -3,9 +3,16 @@ name: Publish to NuGet
 on:
   push:
     tags:
-      # Only publish on version tags (e.g. 8.1.0 or v8.1.0), not arbitrary tags.
+      # Only publish on version tags, not arbitrary tags. Covers stable (8.1.0)
+      # and pre-release (8.2.0-beta) tags, with or without a leading 'v'.
       - '[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+-*'
       - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-*'
+
+# Needed for the Create GitHub Release step to create a release and upload assets.
+permissions:
+  contents: write
 
 jobs:
   publish:
@@ -38,3 +45,20 @@ jobs:
 
     - name: Push to NuGet
       run: dotnet nuget push ./artifacts/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+
+    - name: Create GitHub Release
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        # Auto-generate notes from PRs merged since the previous tag (grouped per
+        # .github/release.yml). Mark pre-release tags (those with a '-' suffix).
+        PRERELEASE=""
+        case "$VERSION" in
+          *-*) PRERELEASE="--prerelease" ;;
+        esac
+        gh release create "$GITHUB_REF_NAME" \
+          --title "$GITHUB_REF_NAME" \
+          --generate-notes \
+          --verify-tag \
+          $PRERELEASE \
+          ./artifacts/*.nupkg

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,79 @@
+name: PR Auto-Labeler
+
+# Applies labels from the PR's conventional-commit title prefix so the
+# auto-generated release notes (.github/release.yml) group it correctly,
+# without anyone having to remember to label by hand. Re-runs on title edits.
+on:
+  pull_request_target:
+    types: [opened, edited, reopened]
+
+# Only needs to add labels. We never check out or execute PR code — the title is
+# treated as data and only regex-matched — so pull_request_target is safe here.
+permissions:
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label from conventional-commit title
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const title = pr.title || "";
+
+            // Conventional-commit type -> label used by .github/release.yml categories.
+            const typeToLabel = {
+              feat: "enhancement", feature: "enhancement",
+              fix: "bug", bugfix: "bug", hotfix: "bug",
+              deps: "dependencies",
+              docs: "documentation", doc: "documentation",
+              ci: "ci", cd: "ci",
+              test: "tests", tests: "tests",
+              chore: "chore", refactor: "chore", perf: "chore",
+              style: "chore", build: "chore",
+            };
+            const colors = {
+              enhancement: "a2eeef", bug: "d73a4a", dependencies: "0366d6",
+              documentation: "0075ca", ci: "ededed", tests: "c5def5",
+              chore: "fef2c0", "breaking-change": "b60205",
+            };
+
+            // e.g. "feat(auth)!: ..." -> type=feat, scope=(auth), breaking=!
+            const m = title.match(/^([a-zA-Z]+)(\([^)]*\))?(!)?:/);
+            const wanted = new Set();
+            if (m) {
+              const label = typeToLabel[m[1].toLowerCase()];
+              if (label) wanted.add(label);
+              if (m[3] === "!") wanted.add("breaking-change");
+            }
+            if (/breaking[ -]change/i.test(title) || /breaking[ -]change/i.test(pr.body || "")) {
+              wanted.add("breaking-change");
+            }
+
+            if (wanted.size === 0) {
+              core.info(`No conventional-commit prefix in title: "${title}". Leaving it for the "Other Changes" bucket.`);
+              return;
+            }
+
+            const { owner, repo } = context.repo;
+            // Ensure each label exists (create on first use) before applying.
+            for (const name of wanted) {
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name });
+              } catch (e) {
+                if (e.status === 404) {
+                  await github.rest.issues.createLabel({ owner, repo, name, color: colors[name] || "ededed" });
+                  core.info(`Created missing label: ${name}`);
+                } else {
+                  throw e;
+                }
+              }
+            }
+
+            // Additive only — never removes labels a maintainer set by hand.
+            await github.rest.issues.addLabels({
+              owner, repo, issue_number: pr.number, labels: [...wanted],
+            });
+            core.info(`Applied labels: ${[...wanted].join(", ")}`);


### PR DESCRIPTION
## What & why

Releases are tag-driven (`nuget-publish.yml` runs on a version tag push), but they only pushed to NuGet — no GitHub Release, no release notes, and nothing tying the two together. This adds a zero-maintenance release-notes flow: **tag and push, GitHub writes the notes itself** from merged PRs. A companion auto-labeler keeps those notes well-categorized without anyone having to remember to label PRs by hand.

## Automated GitHub Release (`nuget-publish.yml`, `.github/release.yml`)

On a version-tag push, after the NuGet push the workflow now also:

- Creates a **GitHub Release** via `gh release create "$GITHUB_REF_NAME" --generate-notes` — notes are generated by GitHub from the PRs merged since the previous tag. No `CHANGELOG.md` to maintain.
- Groups the notes via `.github/release.yml` into ⚠️ Breaking Changes / 🚀 Features / 🐛 Bug Fixes / 📦 Dependencies / 📝 Documentation / 🔧 Maintenance & CI / **Other Changes** (catch-all, so nothing is ever dropped).
- Attaches the built `.nupkg` as a release asset.
- Marks pre-release tags (`X.Y.Z-suffix`) as GitHub pre-releases, and extends the publish trigger to cover pre-release tags (with or without a leading `v`) — which also restores beta-tag publishing.
- Adds `permissions: contents: write` (uses the built-in `GITHUB_TOKEN`; no new secret).

## PR auto-labeler (`pr-labeler.yml`)

GitHub's native note generator categorizes **only by label**, not by commit/PR title. Since this repo already uses conventional-commit titles, a small `pull_request_target` + `actions/github-script` workflow maps the title prefix to the label `.github/release.yml` expects:

| Title prefix | Label |
|---|---|
| `feat:` / `feature:` | `enhancement` |
| `fix:` / `bugfix:` / `hotfix:` | `bug` |
| `deps:` | `dependencies` |
| `docs:` | `documentation` |
| `ci:` / `cd:` | `ci` |
| `test:` / `chore:` / `refactor:` / `perf:` | `tests` / `chore` |
| `type!:` or "BREAKING CHANGE" | `breaking-change` |

- Creates any missing label on first use; **additive only** (never removes maintainer-applied labels).
- Re-runs on title edits, so correcting a prefix re-labels automatically.
- An unmatched title simply lands in "Other Changes" — nothing breaks.

## Safety

- The PR title is read through the `github-script` `context` object (never shell-interpolated), and the job never checks out or runs PR code, so `pull_request_target` is safe; the only granted scope is `pull-requests: write`.