### PR TITLE
test: fix integration flakiness from shared-etcd cross-contamination

### DIFF
--- a/dotnet-etcd.Tests/Integration/WatchResilienceTests.cs
+++ b/dotnet-etcd.Tests/Integration/WatchResilienceTests.cs
@@ -16,9 +16,10 @@ namespace dotnet_etcd.Tests.Integration
         private readonly EtcdClient _client;
         private readonly string _testKeyPrefix = "watch-resilience-";
         
-        // Use etcd1 (port 2379) as per standard test env
-        private const string EtcdUrl = "http://localhost:2379";
-        private const string ContainerName = "etcd1";
+        // Dedicated single-node etcd (port 2409) so pausing/restarting the server here never
+        // disrupts the shared etcd1 cluster used by the other integration tests.
+        private const string EtcdUrl = "http://localhost:2409";
+        private const string ContainerName = "etcd-resilience";
 
         public WatchResilienceTests()
         {

--- a/dotnet-etcd.Tests/docker-compose.yml
+++ b/dotnet-etcd.Tests/docker-compose.yml
@@ -95,6 +95,23 @@ services:
     networks:
       - etcd-net
 
+  # Dedicated single-node etcd for WatchResilienceTests, which pause/restart their server.
+  # Isolated on its own port so that disruption never affects the shared etcd1 cluster tests.
+  etcd-resilience:
+    image: quay.io/coreos/etcd:v3.5.21
+    container_name: etcd-resilience
+    ports:
+      - "2409:2379"
+    command:
+      - /usr/local/bin/etcd
+      - --name=etcd-resilience
+      - --data-dir=/etcd-data
+      - --listen-client-urls=http://0.0.0.0:2379
+      - --advertise-client-urls=http://localhost:2409
+    restart: always
+    networks:
+      - etcd-net
+
 networks:
   etcd-net:
     driver: bridge

--- a/dotnet-etcd.Tests/dotnet-etcd.Tests.csproj
+++ b/dotnet-etcd.Tests/dotnet-etcd.Tests.csproj
@@ -41,6 +41,10 @@
         <Content Include="certs\**">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </Content>
+        <!-- Serialize test collections: the integration tests share a single etcd instance and
+             mutate global state (auth enable/disable, server restart), so running collections in
+             parallel causes cross-test interference and flakiness. -->
+        <None Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
     </ItemGroup>
 
 </Project>

--- a/dotnet-etcd.Tests/xunit.runner.json
+++ b/dotnet-etcd.Tests/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "parallelizeTestCollections": false
+}


### PR DESCRIPTION
## Problem

The nightly **Beast** (flakiness) workflow kept failing `WatchResilienceTests.Watch_ShouldRecover_AfterServerRestart` with `Assert.NotEmpty() Failure: Collection was empty` — even after the revision-resume fix in #310.

## Root cause: test cross-contamination on the single shared `etcd1`

Not the reconnect logic. Confirmed by experiment:

1. **Parallel collections + shared auth state.** xUnit runs different test *collections* in parallel, and there was no assembly-wide guard. `AuthClientIntegrationTests` enables/disables **cluster-wide auth on `etcd1`**. Any other test hitting `etcd1` unauthenticated during that window fails with `etcdserver: user name is empty` — so the resilience watch receives no events → empty collection. (Verified: manually enabling auth makes the test fail immediately.)
2. **Resilience tests disrupt the shared server.** `WatchResilienceTests` pause/restart their etcd, breaking whatever test runs next on `etcd1` — parallel *or* serial (serializing alone surfaced `EtcdClientIntegrationTests` HTTP/2 failures against a paused `etcd1`).

## Fix

- **`xunit.runner.json` with `parallelizeTestCollections: false`** — collections run sequentially, so auth toggling can't overlap other `etcd1` tests.
- **Dedicated `etcd-resilience` container** (single node, port 2409) for `WatchResilienceTests`, so pausing/restarting it never touches the shared `etcd1` cluster.

## Verification

- Full integration suite: **57/57 green** (62s).
- Both resilience tests pass against the dedicated instance; restarting it leaves `etcd1` untouched.

Follow-up to #310 — together these resolve the recurring nightly Beast failures.
